### PR TITLE
Add security with secret to validate allowed clients

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,6 @@
 pytest
 pytest-mock
 pytest-dotenv
+flake8
+black
 -r src/requirements.txt

--- a/src/pr_standard.py
+++ b/src/pr_standard.py
@@ -5,9 +5,11 @@ import re
 try:
     from thirdparties import github
     import error_handler
+    import security
 except ModuleNotFoundError:  # For tests
     from .thirdparties import github
     from . import error_handler
+    from . import security
 
 logger = logging.getLogger()
 
@@ -107,6 +109,7 @@ def _validate_pr(pull_request):
 
 
 @error_handler.wrapper_for("github")
+@security.secret_handler
 def handler(event, context):
     """
     Lambda handler expecting a Pull Request event from GitHub.

--- a/src/pr_standard.py
+++ b/src/pr_standard.py
@@ -109,7 +109,7 @@ def _validate_pr(pull_request):
 
 
 @error_handler.wrapper_for("github")
-@security.secret_handler
+@security.secret_handler("X-Hub-Signature")
 def handler(event, context):
     """
     Lambda handler expecting a Pull Request event from GitHub.

--- a/src/quality_summary.py
+++ b/src/quality_summary.py
@@ -188,7 +188,7 @@ def _update_github_pr(summary_url, statuses_url, cov_report, quality_report, foo
 
 # Although it's CI, GitHub fail response fits good though
 @error_handler.wrapper_for("github")
-@security.secret_handler("FT-Signature")
+@security.secret_handler("Ft-Signature")
 def ci_handler(event, context):
     """
     Expects to receive a payload from CircleCI with following info:

--- a/src/quality_summary.py
+++ b/src/quality_summary.py
@@ -5,10 +5,12 @@ try:
     from thirdparties import github
     from aws import dynamodb, s3
     import error_handler
+    import security
 except ModuleNotFoundError:  # For tests
     from .thirdparties import github
     from .aws import dynamodb, s3
     from . import error_handler
+    from . import security
 
 COV_EMPTY_TEXT = "No lines with coverage information in this diff."
 COV_REPORT_FOOTER = "See details in the [**coverage report**](#COV_LINK#)."
@@ -186,6 +188,7 @@ def _update_github_pr(summary_url, statuses_url, cov_report, quality_report, foo
 
 # Although it's CI, GitHub fail response fits good though
 @error_handler.wrapper_for("github")
+@security.secret_handler("FT-Signature")
 def ci_handler(event, context):
     """
     Expects to receive a payload from CircleCI with following info:
@@ -214,6 +217,7 @@ def ci_handler(event, context):
 
 
 @error_handler.wrapper_for("github")
+@security.secret_handler("X-Hub-Signature")
 def gh_handler(event, context):
     ghevent = json.loads(event.get("body"))
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,3 @@
-requests==2.20.0
+# Pinned both versioms below to avoid random syntax errors ocurring in boto within lambda
 boto3==1.9.60
+futures==2.2.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,2 @@
 requests==2.20.0
-boto3
+boto3==1.9.60

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,4 @@
+requests==2.20.0
 # Pinned both versioms below to avoid random syntax errors ocurring in boto within lambda
 boto3==1.9.60
 futures==2.2.0

--- a/src/security.py
+++ b/src/security.py
@@ -21,8 +21,8 @@ def validate_secret(signature, body):
         logger.error("No signature found")
         return False
 
-    sha_name, signature = signature.split('=')
-    if sha_name != 'sha1':
+    sha_name, signature = signature.split("=")
+    if sha_name != "sha1":
         logger.error("Signature not signed with sha1")
         return False
 
@@ -38,16 +38,19 @@ def validate_secret(signature, body):
 
     return True
 
-def secret_handler(func):
-    def _wrapper(event, *args, **kwargs):
-        print("Secret handler attached")
+def secret_handler(signature_header):
+    def _outer_wrapper(func):
+        def _wrapper(event, *args, **kwargs):
+            print("Secret handler attached")
 
-        signature = event.get('headers', {}).get('X-Hub-Signature', '')
-        body = event.get('body')
+            signature = event.get("headers", {}).get(signature_header, "")
+            body = event.get("body")
 
-        if validate_secret(signature, body):
-            return func(event, *args, **kwargs)
+            if validate_secret(signature, body):
+                return func(event, *args, **kwargs)
 
-        return INVALID_SIGNATURE_RESPONSE
+            return INVALID_SIGNATURE_RESPONSE
 
-    return _wrapper
+        return _wrapper
+
+    return _outer_wrapper

--- a/src/security.py
+++ b/src/security.py
@@ -48,3 +48,5 @@ def secret_handler(func):
             return func(event, *args, **kwargs)
 
         return INVALID_SIGNATURE_RESPONSE
+
+    return _wrapper

--- a/src/security.py
+++ b/src/security.py
@@ -26,7 +26,7 @@ def validate_secret(signature, body):
         logger.error("Signature not signed with sha1")
         return False
 
-    mac = hmac.new(secret, msg=body, digestmod=hashlib.sha1)
+    mac = hmac.new(secret, msg=body.encode(), digestmod=hashlib.sha1)
 
     expected = str(mac.hexdigest())
     received = str(signature)

--- a/src/security.py
+++ b/src/security.py
@@ -1,0 +1,50 @@
+import hashlib
+import hmac
+import json
+import logging
+import os
+
+logger = logging.getLogger()
+
+INVALID_SIGNATURE_RESPONSE = {
+    "statusCode": 404
+}
+
+def _get_secret():
+    return os.environ.get("LAMBDA_SECRET", "secretless")
+
+def validate_secret(signature, body):
+    secret = _get_secret()
+
+    if not signature:
+        logger.error("No signature found")
+        return False
+
+    sha_name, signature = signature.split('=')
+    if sha_name != 'sha1':
+        logger.error("Signature not signed with sha1")
+        return False
+
+    mac = hmac.new(secret, msg=body, digestmod=hashlib.sha1)
+
+    expected = str(mac.hexdigest())
+    received = str(signature)
+
+    matches = hmac.compare_digest(expected, received)
+    if not matches:
+        logger.error(f"Signature ({received}) does not match expected ({expected})")
+        return False
+
+    return True
+
+def secret_handler(func):
+    def _wrapper(event, *args, **kwargs):
+        print("Secret handler attached")
+
+        signature = event.get('headers', {}).get('X-Hub-Signature', '')
+        body = event.get('body')
+
+        if validate_secret(signature, body):
+            return func(event, *args, **kwargs)
+
+        return INVALID_SIGNATURE_RESPONSE

--- a/src/security.py
+++ b/src/security.py
@@ -11,7 +11,8 @@ INVALID_SIGNATURE_RESPONSE = {
 }
 
 def _get_secret():
-    return os.environ.get("LAMBDA_SECRET", "secretless")
+    raw = os.environ.get("LAMBDA_SECRET", "secretless")
+    return raw.encode()
 
 def validate_secret(signature, body):
     secret = _get_secret()

--- a/tests/unit/test_pr_standard.py
+++ b/tests/unit/test_pr_standard.py
@@ -103,6 +103,7 @@ def test_lambda_handler(event_creator, incoming_open_pr_payload, mocker):
     github_payload = json.loads(event["body"])
 
     report = {}
+    mocker.patch.object(pr_standard.security, "validate_secret", return_value=True)
     update_pr_status_mock = mocker.patch.object(
         pr_standard.github, "update_pr_status", return_value=MagicMock(ok=True)
     )
@@ -133,6 +134,7 @@ def test_lambda_handler_invalid_pr(event_creator, incoming_open_pr_payload, mock
     github_payload = json.loads(event["body"])
 
     report = {}
+    mocker.patch.object(pr_standard.security, "validate_secret", return_value=True)
     update_pr_status_mock = mocker.patch.object(
         pr_standard.github, "update_pr_status", return_value=MagicMock(ok=True)
     )
@@ -163,6 +165,7 @@ def test_lambda_handler_handles_exception(
 ):
     event = event_creator(incoming_open_pr_payload)
 
+    mocker.patch.object(pr_standard.security, "validate_secret", return_value=True)
     mocker.patch.object(pr_standard, "_validate_pr", return_value=({}, True, "reason"))
     mocker.patch.object(
         pr_standard.github,


### PR DESCRIPTION
Created and applied `security_handler` to quality and standard functions as suggested in docs: https://developer.github.com/webhooks/securing/ .

Also added a `Ft-Signature` header to follow the same signature logic when running stuff from our CI environment.